### PR TITLE
Use GitHub Pages

### DIFF
--- a/.github/workflows/CODEOWNERS
+++ b/.github/workflows/CODEOWNERS
@@ -1,1 +1,0 @@
-* @boundless-forest

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,4 +1,4 @@
-name: Deploy develop
+name: Deploy PR preview
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    name: Deploy
+    name: Deploy pages
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -1,13 +1,9 @@
-name: Deploy with GitHub Pages
-
-# on:
-#   push:
-#     tags:
-#       - 'v*'
+name: Deploy production with GitHub Pages
 
 on:
-  pull_request:
-  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -30,6 +26,8 @@ jobs:
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -1,13 +1,31 @@
-name: Deploy production
+name: Deploy with GitHub Pages
+
+# on:
+#   push:
+#     tags:
+#       - 'v*'
 
 on:
-  push:
-    tags:
-      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   deploy:
-    name: Deploy pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Fetch latest code
@@ -21,22 +39,12 @@ jobs:
           pip3 install poetry
           poetry run poetry install --no-root
           poetry run mkdocs build
-      - name: Setup Vercel environment
-        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          repository: darwinia-network/devops
-          path: .github
-      - name: Deploy to Vercel
-        uses: ./.github/actions/smart-vercel
-        with:
-          vercel_token: ${{ secrets.VERCEL_TOKEN }}
-          vercel_group: itering
-          preview_output: true
-          project_name: darwinia-docs
-          dist_path: site
-          prod_mode: true
-          script_run: false
-          enable_cache: true
-          enable_notify_slack: true
-          slack_channel: darwinia-document
-          slack_webhook: ${{ secrets.SLACK_INCOMING_WEBHOOK_URL }}
+          path: "site"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Fetch latest code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/deploy-stg.yml
+++ b/.github/workflows/deploy-stg.yml
@@ -1,4 +1,4 @@
-name: Deploy staging
+name: Deploy staging preview
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# System
+.DS_Store
+
+# Integrated Development Environment
+.idea
+.vscode
+
+# Cache
+site


### PR DESCRIPTION
1. Use GitHub Pages to host the production release, and reserve Vercel exclusively for previews.
    1. Vercel will be completely removed after #28.
2. Improve the history feature.
3. Add gitignore for local development.

### Before
https://docs.darwinia.network/msgport/overview/#embracing-the-future
<img width="392" alt="image" src="https://github.com/darwinia-network/document/assets/16152305/e1c9ca7e-4e04-4ed3-a001-b3b2142a872c">

### After
https://aurevoirxavier.github.io/document/msgport/overview/#embracing-the-future
<img width="434" alt="image" src="https://github.com/darwinia-network/document/assets/16152305/94535141-0399-4118-b6db-b3512a8b1772">

And get a GitHub Pages status preview in the project home page.

<img width="233" alt="image" src="https://github.com/darwinia-network/document/assets/16152305/840fb0f9-1885-4187-b98f-655c42c82eae">